### PR TITLE
decoupling profilepic from display config / nfts slice

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -68,9 +68,9 @@ const (
 
 const (
 	// This number should never be lower than the total count returned by default profile, so that new users can always save their initial profile
-	REGULAR_TOTAL_BADGE_COUNT uint = 25
+	REGULAR_TOTAL_BADGE_COUNT uint = 26
 	PREMIUM_TOTAL_BADGE_COUNT uint = 50
 	// Reminder: making these numbers bigger has implications for the max badge limit above. When a new user tries to save their default profile for the first time they may fail due to being above the badge limit
 	DEFAULT_TOKEN_CUTOFF uint = 6
-	DEFAULT_NFT_CUTOFF   uint = 12
+	DEFAULT_NFT_CUTOFF   uint = 13
 )

--- a/profiles-api/entities/profile.go
+++ b/profiles-api/entities/profile.go
@@ -8,7 +8,8 @@ type Profile struct {
 	LastModified      *time.Time // LastModified can be nil if this is a defaul profile
 	ENSName           string
 	StoreAssets       *StoreAssets
-	DisplayConfig     *DisplayConfig // DisplayConfig can be nil if this is a default profile
+	DisplayConfig     *DisplayConfig    // DisplayConfig can be nil if this is a default profile
+	ProfilePicture    *NonFungibleToken // can be nil if this is a default profile
 	NonFungibleTokens *[]NonFungibleToken
 	FungibleTokens    *[]FungibleToken
 	Statistics        *[]Statistic

--- a/profiles-api/entities/profile.go
+++ b/profiles-api/entities/profile.go
@@ -9,7 +9,7 @@ type Profile struct {
 	ENSName           string
 	StoreAssets       *StoreAssets
 	DisplayConfig     *DisplayConfig    // DisplayConfig can be nil if this is a default profile
-	ProfilePicture    *NonFungibleToken // can be nil if this is a default profile
+	ProfilePicture    *NonFungibleToken // ProfilePicture can be nil if this is a default profile with no NFTs or they have simply removed their profile picture
 	NonFungibleTokens *[]NonFungibleToken
 	FungibleTokens    *[]FungibleToken
 	Statistics        *[]Statistic

--- a/profiles-api/gateways/mongo/gateway.go
+++ b/profiles-api/gateways/mongo/gateway.go
@@ -45,6 +45,7 @@ type profileBson struct {
 	Banned            bool                    `bson:"banned,omitempty"`
 	LastModified      *time.Time              `bson:"last_modified"`
 	DisplayConfig     *displayConfigBson      `bson:"display_config"`
+	ProfilePicture    *nonFungibleTokenBson   `bson:"profile_picture"`
 	NonFungibleTokens *[]nonFungibleTokenBson `bson:"non_fungible_tokens"`
 	FungibleTokens    *[]fungibleTokenBson    `bson:"fungible_tokens"`
 	Statistics        *[]statisticBson        `bson:"statistics"`
@@ -251,10 +252,23 @@ func fromProfileBson(profileBson *profileBson) *entities.Profile {
 		config.Groups = &groups
 	}
 
+	var profilePicture *entities.NonFungibleToken
+	if profileBson.ProfilePicture != nil {
+		profilePicture = &entities.NonFungibleToken{
+			TokenId: profileBson.ProfilePicture.TokenId,
+			Contract: &entities.Contract{
+				Blockchain: profileBson.ProfilePicture.Contract.Blockchain,
+				Address:    profileBson.ProfilePicture.Contract.Address,
+				Interface:  profileBson.ProfilePicture.Contract.Interface,
+			},
+		}
+	}
+
 	return &entities.Profile{
 		Address:           profileBson.Address,
 		Banned:            profileBson.Banned,
 		LastModified:      profileBson.LastModified,
+		ProfilePicture:    profilePicture,
 		DisplayConfig:     &config,
 		NonFungibleTokens: &nfts,
 		FungibleTokens:    &tokens,
@@ -378,10 +392,23 @@ func toProfileBson(profile *entities.Profile) *profileBson {
 		config.Groups = &groups
 	}
 
+	var profilePicture *nonFungibleTokenBson
+	if profile.ProfilePicture != nil {
+		profilePicture = &nonFungibleTokenBson{
+			TokenId: profile.ProfilePicture.TokenId,
+			Contract: &contractBson{
+				Blockchain: profile.ProfilePicture.Contract.Blockchain,
+				Address:    profile.ProfilePicture.Contract.Address,
+				Interface:  profile.ProfilePicture.Contract.Interface,
+			},
+		}
+	}
+
 	lastModified := time.Now().UTC()
 	return &profileBson{
 		Address:           profile.Address,
 		LastModified:      &lastModified,
+		ProfilePicture:    profilePicture,
 		DisplayConfig:     &config,
 		NonFungibleTokens: &nfts,
 		FungibleTokens:    &tokens,

--- a/profiles-api/gateways/offchain/crypto_punks.go
+++ b/profiles-api/gateways/offchain/crypto_punks.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/etheralley/etheralley-backend/profiles-api/entities"
 )
@@ -19,7 +19,7 @@ const filename = "profiles-api/gateways/offchain/assets/cryptopunks/metadata.jso
 
 // json metadata is read into memory on app init
 func (gw *gateway) initPunkMetadata() error {
-	file, err := ioutil.ReadFile(filename)
+	file, err := os.ReadFile(filename)
 
 	if err != nil {
 		return fmt.Errorf("could not read %v: %w", filename, err)

--- a/profiles-api/gateways/offchain/nfts.go
+++ b/profiles-api/gateways/offchain/nfts.go
@@ -38,7 +38,7 @@ type responseMetadataJson struct {
 // See https://docs.alchemy.com/alchemy/enhanced-apis/nft-api/getnfts
 // TODO: Polygon is also supported if we want to fetch from both in the future
 func (gw *gateway) GetNonFungibleTokens(ctx context.Context, address string) (*[]entities.NonFungibleToken, error) {
-	url := fmt.Sprintf("%v/getNFTs?owner=%v&filters[]=SPAM", gw.settings.AlchemyEthereumURI(), address)
+	url := fmt.Sprintf("%v/getNFTs?owner=%v&filters[]=SPAM&pageSize=25", gw.settings.AlchemyEthereumURI(), address)
 
 	resp, err := gw.httpClient.Do(ctx, "GET", url, nil, &common.HttpOptions{})
 

--- a/profiles-api/gateways/offchain/tokens.go
+++ b/profiles-api/gateways/offchain/tokens.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -23,7 +23,7 @@ type tokenMetadata map[string]struct {
 // json metadata is read into memory on app init
 func (gw *gateway) initTokenMetadata() error {
 	for _, blockchain := range []common.Blockchain{common.ARBITRUM, common.ETHEREUM, common.POLYGON, common.OPTIMISM} {
-		file, err := ioutil.ReadFile(fmt.Sprintf("profiles-api/gateways/offchain/assets/tokens/%v.json", blockchain))
+		file, err := os.ReadFile(fmt.Sprintf("profiles-api/gateways/offchain/assets/tokens/%v.json", blockchain))
 
 		if err != nil {
 			return fmt.Errorf("could not read %v: %w", blockchain, err)

--- a/profiles-api/gateways/redis/gateway.go
+++ b/profiles-api/gateways/redis/gateway.go
@@ -65,6 +65,7 @@ type profileJson struct {
 	ENSName           string                  `json:"ens_name"`
 	DisplayConfig     *displayConfigJson      `json:"display_config,omitempty"`
 	StoreAssets       *storeAssetsJson        `json:"store_assets"`
+	ProfilePicture    *nonFungibleTokenJson   `json:"profile_picture"`
 	NonFungibleTokens *[]nonFungibleTokenJson `json:"non_fungible_tokens"`
 	FungibleTokens    *[]fungibleTokenJson    `json:"fungible_tokens"`
 	Statistics        *[]statisticJson        `json:"statistics"`
@@ -325,6 +326,25 @@ func fromProfileJson(profileJson *profileJson) *entities.Profile {
 		}
 	}
 
+	var profilePicture *entities.NonFungibleToken
+	if profileJson.ProfilePicture != nil {
+		profilePicture = &entities.NonFungibleToken{
+			TokenId: profileJson.ProfilePicture.TokenId,
+			Contract: &entities.Contract{
+				Blockchain: profileJson.ProfilePicture.Contract.Blockchain,
+				Address:    profileJson.ProfilePicture.Contract.Address,
+				Interface:  profileJson.ProfilePicture.Contract.Interface,
+			},
+			Balance: profileJson.ProfilePicture.Balance,
+			Metadata: &entities.NonFungibleMetadata{
+				Name:        profileJson.ProfilePicture.Metadata.Name,
+				Description: profileJson.ProfilePicture.Metadata.Description,
+				Image:       profileJson.ProfilePicture.Metadata.Image,
+				Attributes:  profileJson.ProfilePicture.Metadata.Attributes,
+			},
+		}
+	}
+
 	return &entities.Profile{
 		Address:      profileJson.Address,
 		Banned:       profileJson.Banned,
@@ -334,6 +354,7 @@ func fromProfileJson(profileJson *profileJson) *entities.Profile {
 			Premium:    profileJson.StoreAssets.Premium,
 			BetaTester: profileJson.StoreAssets.BetaTester,
 		},
+		ProfilePicture:    profilePicture,
 		DisplayConfig:     config,
 		NonFungibleTokens: &nfts,
 		FungibleTokens:    &tokens,
@@ -504,6 +525,25 @@ func toProfileJson(profile *entities.Profile) *profileJson {
 		}
 	}
 
+	var profilePicture *nonFungibleTokenJson
+	if profile.ProfilePicture != nil {
+		profilePicture = &nonFungibleTokenJson{
+			TokenId: profile.ProfilePicture.TokenId,
+			Contract: &contractJson{
+				Blockchain: profile.ProfilePicture.Contract.Blockchain,
+				Address:    profile.ProfilePicture.Contract.Address,
+				Interface:  profile.ProfilePicture.Contract.Interface,
+			},
+			Balance: profile.ProfilePicture.Balance,
+			Metadata: &nonFungibleMetadataJson{
+				Name:        profile.ProfilePicture.Metadata.Name,
+				Description: profile.ProfilePicture.Metadata.Description,
+				Image:       profile.ProfilePicture.Metadata.Image,
+				Attributes:  profile.ProfilePicture.Metadata.Attributes,
+			},
+		}
+	}
+
 	return &profileJson{
 		Address:      profile.Address,
 		Banned:       profile.Banned,
@@ -513,6 +553,7 @@ func toProfileJson(profile *entities.Profile) *profileJson {
 			Premium:    profile.StoreAssets.Premium,
 			BetaTester: profile.StoreAssets.BetaTester,
 		},
+		ProfilePicture:    profilePicture,
 		DisplayConfig:     config,
 		NonFungibleTokens: &nfts,
 		FungibleTokens:    &tokens,

--- a/profiles-api/presenter/presenter.go
+++ b/profiles-api/presenter/presenter.go
@@ -83,6 +83,10 @@ func toChallengeJson(challenge *entities.Challenge) *challengeJson {
 }
 
 func toProfileJson(profile *entities.Profile) *profileJson {
+	var profilePicutre *nonFungibleTokenJson
+	if profile.ProfilePicture != nil {
+		profilePicutre = toNonFungibleJson(profile.ProfilePicture)
+	}
 	return &profileJson{
 		Address:      profile.Address,
 		LastModified: profile.LastModified,
@@ -92,6 +96,7 @@ func toProfileJson(profile *entities.Profile) *profileJson {
 			BetaTester: profile.StoreAssets.BetaTester,
 		},
 		DisplayConfig:     toDisplayConfigJson(profile.DisplayConfig),
+		ProfilePicture:    profilePicutre,
 		NonFungibleTokens: toNonFungibleTokensJson(profile.NonFungibleTokens),
 		FungibleTokens:    toFungibleTokensJson(profile.FungibleTokens),
 		Statistics:        toStatisticsJson(profile.Statistics),
@@ -299,6 +304,7 @@ type profileJson struct {
 	ENSName           string                  `json:"ens_name"`
 	StoreAssets       *storeAssetsJson        `json:"store_assets"`
 	DisplayConfig     *displayConfigJson      `json:"display_config,omitempty"`
+	ProfilePicture    *nonFungibleTokenJson   `json:"profile_picture,omitempty"`
 	NonFungibleTokens *[]nonFungibleTokenJson `json:"non_fungible_tokens"`
 	FungibleTokens    *[]fungibleTokenJson    `json:"fungible_tokens"`
 	Statistics        *[]statisticJson        `json:"statistics"`

--- a/profiles-api/usecases/get_profile.go
+++ b/profiles-api/usecases/get_profile.go
@@ -17,6 +17,7 @@ func NewGetProfile(
 	cacheGateway gateways.ICacheGateway,
 	databaseGateway gateways.IDatabaseGateway,
 	getDefaultProfile IGetDefaultProfileUseCase,
+	getNonFungibleToken IGetNonFungibleTokenUseCase,
 	getAllNonFungibleTokens IGetAllNonFungibleTokensUseCase,
 	getAllFungibleTokens IGetAllFungibleTokensUseCase,
 	getAllStatistics IGetAllStatisticsUseCase,
@@ -29,6 +30,7 @@ func NewGetProfile(
 		cacheGateway,
 		databaseGateway,
 		getDefaultProfile,
+		getNonFungibleToken,
 		getAllNonFungibleTokens,
 		getAllFungibleTokens,
 		getAllStatistics,
@@ -43,6 +45,7 @@ type getProfileUseCase struct {
 	cacheGateway            gateways.ICacheGateway
 	databaseGateway         gateways.IDatabaseGateway
 	getDefaultProfile       IGetDefaultProfileUseCase
+	getNonFungibleToken     IGetNonFungibleTokenUseCase
 	getAllNonFungibleTokens IGetAllNonFungibleTokensUseCase
 	getAllFungibleTokens    IGetAllFungibleTokensUseCase
 	getAllStatistics        IGetAllStatisticsUseCase
@@ -106,7 +109,7 @@ func (uc *getProfileUseCase) Do(ctx context.Context, input *GetProfileInput) (*e
 	uc.logger.Debug(ctx).Msgf("db hit %v", input.Address)
 
 	var wg sync.WaitGroup
-	wg.Add(6)
+	wg.Add(7)
 
 	go func() {
 		defer wg.Done()
@@ -117,6 +120,29 @@ func (uc *getProfileUseCase) Do(ctx context.Context, input *GetProfileInput) (*e
 		})
 
 		profile.ENSName = name
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		if profile.ProfilePicture != nil {
+			picture, err := uc.getNonFungibleToken.Do(ctx, &GetNonFungibleTokenInput{
+				Address: profile.Address,
+				NonFungibleToken: &NonFungibleTokenInput{
+					TokenId: profile.ProfilePicture.TokenId,
+					Contract: &ContractInput{
+						Blockchain: profile.ProfilePicture.Contract.Blockchain,
+						Interface:  profile.ProfilePicture.Contract.Interface,
+						Address:    profile.ProfilePicture.Contract.Address,
+					},
+				},
+			})
+			if err == nil {
+				profile.ProfilePicture = picture
+			} else {
+				uc.logger.Info(ctx).Err(err).Msgf("err getting profile picture: contract address %v token id %v chain %v", profile.ProfilePicture.Contract.Address, profile.ProfilePicture.Contract, profile.ProfilePicture.Contract.Blockchain)
+			}
+		}
 	}()
 
 	go func() {

--- a/profiles-api/usecases/get_profile.go
+++ b/profiles-api/usecases/get_profile.go
@@ -137,11 +137,13 @@ func (uc *getProfileUseCase) Do(ctx context.Context, input *GetProfileInput) (*e
 					},
 				},
 			})
-			if err == nil {
-				profile.ProfilePicture = picture
-			} else {
+
+			if err != nil {
 				uc.logger.Info(ctx).Err(err).Msgf("err getting profile picture: contract address %v token id %v chain %v", profile.ProfilePicture.Contract.Address, profile.ProfilePicture.Contract, profile.ProfilePicture.Contract.Blockchain)
+				return
 			}
+
+			profile.ProfilePicture = picture
 		}
 	}()
 

--- a/profiles-api/usecases/usecase.go
+++ b/profiles-api/usecases/usecase.go
@@ -7,6 +7,7 @@ import (
 type ProfileInput struct {
 	Address           string                   `json:"-" validate:"required,eth_addr"`
 	DisplayConfig     *DisplayConfigInput      `json:"display_config" validate:"required,dive"`
+	ProfilePicture    *NonFungibleTokenInput   `json:"profile_picture" validate:"omitempty,dive"`
 	NonFungibleTokens *[]NonFungibleTokenInput `json:"non_fungible_tokens" validate:"required,dive"`
 	FungibleTokens    *[]FungibleTokenInput    `json:"fungible_tokens" validate:"required,dive"`
 	Statistics        *[]StatisticInput        `json:"statistics" validate:"required,dive"`


### PR DESCRIPTION
Adding ProfilePicture field to profiles entity. In a followup PR and after a data fix, I will remove the concept of profile picture from the display config. This decouples the profile picture hydration from knowledge of the internals of the display config. Doing this will enable a "light profile" usecase that can easily partially hydrate a profile.

Some small fixes included:
- removing usage of ioutil as its depricated
- bumped max badge count to 26 to account for 1 profile picture + 12 nfts + 6 tokens + 4 currencies + 3 stats
- adding an explicit pageSize to the alchemy get all nfts api to try to make it a little faster. Default is 100 which is more than we need. But sometimes the nfts have errors so we want slighly more than 13.